### PR TITLE
bugfix: TrueVault client/api version related errors

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,6 @@
     "morgan": "^1.8.1",
     "node-fetch": "^1.6.3",
     "pg-promise": "^5.6.8",
-    "truevault": "^0.2.0"
+    "truevault": "^1.3.0"
   }
 }

--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -29,8 +29,12 @@ class AdminDashboard extends Component {
 }
 
 const mapStateToProps = (state) => {
+    console.log("admin dashboard mapStateToProps state.login.tvclient", state.login.tvClient);
+    console.log("tvClient.accessToken", state.login.tvClient.accessToken);
+    console.log("tvClient.accessToken", state.login.tvClient.accessToken);
+    
     return {
-        accessToken: state.login.tvClient.apiKeyOrAccessToken,
+        accessToken: state.login.tvClient.accessToken,
         stats: state.statsView.stats,
         statsLoading: state.statsView.loading,
         statsError: state.statsView.error

--- a/src/components/DoctorCaseView.js
+++ b/src/components/DoctorCaseView.js
@@ -11,7 +11,7 @@ import CaseStatus from "./CaseStatus";
 
 class DoctorCaseView extends Component {
     componentWillMount() {
-        const getCaseMetadataRequest = internalApiClient.getCase(this.props.tvClient.apiKeyOrAccessToken, this.props.routeParams.caseId);
+        const getCaseMetadataRequest = internalApiClient.getCase(this.props.tvClient.accessToken, this.props.routeParams.caseId);
 
         this.props.viewCase(this.props.tvClient, getCaseMetadataRequest);
     }
@@ -26,7 +26,7 @@ class DoctorCaseView extends Component {
     submitApproval(e) {
         e.preventDefault();
 
-        this.props.submitApproval(this.props.tvClient.apiKeyOrAccessToken, this.props.routeParams.caseId);
+        this.props.submitApproval(this.props.tvClient.accessToken, this.props.routeParams.caseId);
     }
 
     caseUpdateForm(submitFunction, submitting, formDisabled, buttonLabel) {

--- a/src/components/PatientDashboard.js
+++ b/src/components/PatientDashboard.js
@@ -10,7 +10,7 @@ import CaseStatus from "./CaseStatus";
 
 class PatientDashboard extends Component {
     async componentWillMount() {
-        const caseMetadataRequest = internalApiClient.getPatientCase(this.props.tvClient.apiKeyOrAccessToken);
+        const caseMetadataRequest = internalApiClient.getPatientCase(this.props.tvClient.accessToken);
 
         this.props.viewCase(this.props.tvClient, caseMetadataRequest);
     }

--- a/src/internal-api-client.js
+++ b/src/internal-api-client.js
@@ -103,6 +103,7 @@ class InternalApiClient {
     }
 
     async getAdminDashboardStats(tvAccessToken) {
+        console.log("admin-stats tvAccessToken", tvAccessToken);
         const response = await fetch(`${this.urlPrefix}/api/dashboard/stats`, {
             headers: this.headers(tvAccessToken)
         });


### PR DESCRIPTION
The usage of the truevault clients was not consistent with the way they
are intended to function, and the current API is incompatible with the
server's older client version.  Updates:

* Bumped the server's truevault client to 1.3.0 to match the react app
* Updated the react app's usage to pull from the accessToken field as
  the apiKeyOrAccessToken getter is no longer available; this led to all
  requests routed through the local server to fail because it was not
  including the correct token in the header
* Updated the react app's handling of document search results as it was
  referencing a key that no longer exists